### PR TITLE
victory sequence, status function, bug fixes

### DIFF
--- a/.idea/workspace.xml
+++ b/.idea/workspace.xml
@@ -3,6 +3,7 @@
   <component name="ChangeListManager">
     <list default="true" id="0dd7a9dc-65e9-4850-87c9-5518eca81ce5" name="Default" comment="">
       <change type="MODIFICATION" beforePath="$PROJECT_DIR$/game_main.py" afterPath="$PROJECT_DIR$/game_main.py" />
+      <change type="MODIFICATION" beforePath="$PROJECT_DIR$/game_start.txt" afterPath="$PROJECT_DIR$/game_start.txt" />
     </list>
     <option name="EXCLUDED_CONVERTED_TO_IGNORED" value="true" />
     <option name="TRACKING_ENABLED" value="true" />
@@ -12,40 +13,34 @@
     <option name="LAST_RESOLUTION" value="IGNORE" />
   </component>
   <component name="FileEditorManager">
-    <splitter split-orientation="horizontal" split-proportion="0.5">
-      <split-first>
-        <leaf SIDE_TABS_SIZE_LIMIT_KEY="300">
-          <file leaf-file-name="game_main.py" pinned="false" current-in-tab="true">
-            <entry file="file://$PROJECT_DIR$/game_main.py">
-              <provider selected="true" editor-type-id="text-editor">
-                <state relative-caret-position="-1843">
-                  <caret line="348" column="0" lean-forward="true" selection-start-line="348" selection-start-column="0" selection-end-line="348" selection-end-column="0" />
-                  <folding />
-                </state>
-              </provider>
-            </entry>
-          </file>
-        </leaf>
-      </split-first>
-      <split-second>
-        <leaf SIDE_TABS_SIZE_LIMIT_KEY="300">
-          <file leaf-file-name="game_start.txt" pinned="false" current-in-tab="true">
-            <entry file="file://$PROJECT_DIR$/game_start.txt">
-              <provider selected="true" editor-type-id="text-editor">
-                <state relative-caret-position="1693">
-                  <caret line="104" column="39" lean-forward="false" selection-start-line="104" selection-start-column="39" selection-end-line="104" selection-end-column="39" />
-                  <folding />
-                </state>
-              </provider>
-            </entry>
-          </file>
-        </leaf>
-      </split-second>
-    </splitter>
+    <leaf>
+      <file leaf-file-name="game_main.py" pinned="false" current-in-tab="false">
+        <entry file="file://$PROJECT_DIR$/game_main.py">
+          <provider selected="true" editor-type-id="text-editor">
+            <state relative-caret-position="619">
+              <caret line="530" column="46" lean-forward="false" selection-start-line="530" selection-start-column="46" selection-end-line="530" selection-end-column="46" />
+              <folding />
+            </state>
+          </provider>
+        </entry>
+      </file>
+      <file leaf-file-name="game_start.txt" pinned="false" current-in-tab="true">
+        <entry file="file://$PROJECT_DIR$/game_start.txt">
+          <provider selected="true" editor-type-id="text-editor">
+            <state relative-caret-position="34">
+              <caret line="2" column="90" lean-forward="false" selection-start-line="2" selection-start-column="90" selection-end-line="2" selection-end-column="90" />
+              <folding />
+            </state>
+          </provider>
+        </entry>
+      </file>
+    </leaf>
   </component>
   <component name="FindInProjectRecents">
     <findStrings>
       <find>fight</find>
+      <find>heal</find>
+      <find>items</find>
     </findStrings>
   </component>
   <component name="Git.Settings">
@@ -54,8 +49,8 @@
   <component name="IdeDocumentHistory">
     <option name="CHANGED_PATHS">
       <list>
-        <option value="$PROJECT_DIR$/game_start.txt" />
         <option value="$PROJECT_DIR$/game_main.py" />
+        <option value="$PROJECT_DIR$/game_start.txt" />
       </list>
     </option>
   </component>
@@ -149,14 +144,15 @@
   </component>
   <component name="ToolWindowManager">
     <frame x="-8" y="-8" width="1936" height="1056" extended-state="7" />
+    <editor active="true" />
     <layout>
-      <window_info id="Project" active="false" anchor="left" auto_hide="false" internal_type="DOCKED" type="DOCKED" visible="true" show_stripe_button="true" weight="0.12579957" sideWeight="0.5" order="0" side_tool="false" content_ui="combo" />
+      <window_info id="Project" active="false" anchor="left" auto_hide="false" internal_type="DOCKED" type="DOCKED" visible="false" show_stripe_button="true" weight="0.12579957" sideWeight="0.5" order="0" side_tool="false" content_ui="combo" />
       <window_info id="TODO" active="false" anchor="bottom" auto_hide="false" internal_type="DOCKED" type="DOCKED" visible="false" show_stripe_button="true" weight="0.33" sideWeight="0.5" order="6" side_tool="false" content_ui="tabs" />
       <window_info id="Event Log" active="false" anchor="bottom" auto_hide="false" internal_type="DOCKED" type="DOCKED" visible="false" show_stripe_button="true" weight="0.33" sideWeight="0.5" order="7" side_tool="true" content_ui="tabs" />
-      <window_info id="Run" active="true" anchor="bottom" auto_hide="false" internal_type="DOCKED" type="DOCKED" visible="true" show_stripe_button="true" weight="0.28152174" sideWeight="0.5" order="2" side_tool="false" content_ui="tabs" />
+      <window_info id="Run" active="false" anchor="bottom" auto_hide="false" internal_type="DOCKED" type="DOCKED" visible="true" show_stripe_button="true" weight="0.28152174" sideWeight="0.5" order="2" side_tool="false" content_ui="tabs" />
       <window_info id="Version Control" active="false" anchor="bottom" auto_hide="false" internal_type="DOCKED" type="DOCKED" visible="false" show_stripe_button="true" weight="0.33" sideWeight="0.5" order="7" side_tool="false" content_ui="tabs" />
       <window_info id="Python Console" active="false" anchor="bottom" auto_hide="false" internal_type="DOCKED" type="DOCKED" visible="false" show_stripe_button="true" weight="0.32934782" sideWeight="0.5" order="7" side_tool="false" content_ui="tabs" />
-      <window_info id="Structure" active="false" anchor="left" auto_hide="false" internal_type="DOCKED" type="DOCKED" visible="false" show_stripe_button="true" weight="0.25" sideWeight="0.5" order="1" side_tool="false" content_ui="tabs" />
+      <window_info id="Structure" active="false" anchor="left" auto_hide="false" internal_type="DOCKED" type="DOCKED" visible="true" show_stripe_button="true" weight="0.25" sideWeight="0.5" order="1" side_tool="false" content_ui="tabs" />
       <window_info id="Terminal" active="false" anchor="bottom" auto_hide="false" internal_type="DOCKED" type="DOCKED" visible="false" show_stripe_button="true" weight="0.33" sideWeight="0.5" order="7" side_tool="false" content_ui="tabs" />
       <window_info id="Debug" active="false" anchor="bottom" auto_hide="false" internal_type="DOCKED" type="DOCKED" visible="false" show_stripe_button="true" weight="0.4" sideWeight="0.5" order="3" side_tool="false" content_ui="tabs" />
       <window_info id="Favorites" active="false" anchor="left" auto_hide="false" internal_type="DOCKED" type="DOCKED" visible="false" show_stripe_button="true" weight="0.33" sideWeight="0.5" order="2" side_tool="true" content_ui="tabs" />
@@ -210,18 +206,42 @@
         </state>
       </provider>
     </entry>
-    <entry file="file://$PROJECT_DIR$/game_start.txt">
+    <entry file="file://$PROJECT_DIR$/initial_game_planning.txt">
       <provider selected="true" editor-type-id="text-editor">
-        <state relative-caret-position="1693">
-          <caret line="104" column="39" lean-forward="false" selection-start-line="104" selection-start-column="39" selection-end-line="104" selection-end-column="39" />
+        <state relative-caret-position="0">
+          <caret line="0" column="0" lean-forward="false" selection-start-line="0" selection-start-column="0" selection-end-line="0" selection-end-column="0" />
+          <folding />
+        </state>
+      </provider>
+    </entry>
+    <entry file="file://$PROJECT_DIR$/README.md">
+      <provider selected="true" editor-type-id="text-editor">
+        <state relative-caret-position="0">
+          <caret line="0" column="0" lean-forward="false" selection-start-line="0" selection-start-column="0" selection-end-line="0" selection-end-column="0" />
+          <folding />
+        </state>
+      </provider>
+    </entry>
+    <entry file="file://$PROJECT_DIR$/readme.txt">
+      <provider selected="true" editor-type-id="text-editor">
+        <state relative-caret-position="0">
+          <caret line="0" column="0" lean-forward="false" selection-start-line="0" selection-start-column="0" selection-end-line="0" selection-end-column="0" />
           <folding />
         </state>
       </provider>
     </entry>
     <entry file="file://$PROJECT_DIR$/game_main.py">
       <provider selected="true" editor-type-id="text-editor">
-        <state relative-caret-position="-1843">
-          <caret line="348" column="0" lean-forward="true" selection-start-line="348" selection-start-column="0" selection-end-line="348" selection-end-column="0" />
+        <state relative-caret-position="619">
+          <caret line="530" column="46" lean-forward="false" selection-start-line="530" selection-start-column="46" selection-end-line="530" selection-end-column="46" />
+          <folding />
+        </state>
+      </provider>
+    </entry>
+    <entry file="file://$PROJECT_DIR$/game_start.txt">
+      <provider selected="true" editor-type-id="text-editor">
+        <state relative-caret-position="34">
+          <caret line="2" column="90" lean-forward="false" selection-start-line="2" selection-start-column="90" selection-end-line="2" selection-end-column="90" />
           <folding />
         </state>
       </provider>

--- a/.idea/workspace.xml
+++ b/.idea/workspace.xml
@@ -2,7 +2,6 @@
 <project version="4">
   <component name="ChangeListManager">
     <list default="true" id="0dd7a9dc-65e9-4850-87c9-5518eca81ce5" name="Default" comment="">
-      <change type="MODIFICATION" beforePath="$PROJECT_DIR$/game_main.py" afterPath="$PROJECT_DIR$/game_main.py" />
       <change type="MODIFICATION" beforePath="$PROJECT_DIR$/game_start.txt" afterPath="$PROJECT_DIR$/game_start.txt" />
     </list>
     <option name="EXCLUDED_CONVERTED_TO_IGNORED" value="true" />
@@ -17,9 +16,23 @@
       <file leaf-file-name="game_main.py" pinned="false" current-in-tab="false">
         <entry file="file://$PROJECT_DIR$/game_main.py">
           <provider selected="true" editor-type-id="text-editor">
-            <state relative-caret-position="619">
-              <caret line="530" column="46" lean-forward="false" selection-start-line="530" selection-start-column="46" selection-end-line="530" selection-end-column="46" />
-              <folding />
+            <state relative-caret-position="-248">
+              <caret line="475" column="46" lean-forward="false" selection-start-line="475" selection-start-column="46" selection-end-line="475" selection-end-column="46" />
+              <folding>
+                <marker date="1511510431907" expanded="true" signature="126:134" ph="&quot;&quot;&quot;...&quot;&quot;&quot;" />
+                <marker date="1511510431907" expanded="true" signature="18977:19071" ph="..." />
+                <marker date="1511510431907" expanded="true" signature="18977:19170" ph="..." />
+                <marker date="1511510431907" expanded="true" signature="19205:19301" ph="..." />
+                <marker date="1511510431907" expanded="true" signature="19324:19665" ph="..." />
+                <marker date="1511510431907" expanded="true" signature="19377:19665" ph="..." />
+                <marker date="1511510431907" expanded="true" signature="19474:19608" ph="..." />
+                <marker date="1511510431907" expanded="true" signature="19706:20248" ph="..." />
+                <marker date="1511510431907" expanded="true" signature="19763:20248" ph="..." />
+                <marker date="1511510431907" expanded="true" signature="19848:19908" ph="..." />
+                <marker date="1511510431907" expanded="true" signature="19968:20149" ph="..." />
+                <marker date="1511510431907" expanded="true" signature="19995:20149" ph="..." />
+                <marker date="1511510431907" expanded="true" signature="20311:20341" ph="..." />
+              </folding>
             </state>
           </provider>
         </entry>
@@ -27,8 +40,8 @@
       <file leaf-file-name="game_start.txt" pinned="false" current-in-tab="true">
         <entry file="file://$PROJECT_DIR$/game_start.txt">
           <provider selected="true" editor-type-id="text-editor">
-            <state relative-caret-position="34">
-              <caret line="2" column="90" lean-forward="false" selection-start-line="2" selection-start-column="90" selection-end-line="2" selection-end-column="90" />
+            <state relative-caret-position="1887">
+              <caret line="111" column="27" lean-forward="true" selection-start-line="111" selection-start-column="27" selection-end-line="111" selection-end-column="27" />
               <folding />
             </state>
           </provider>
@@ -54,7 +67,7 @@
       </list>
     </option>
   </component>
-  <component name="ProjectFrameBounds" extendedState="7">
+  <component name="ProjectFrameBounds" extendedState="6">
     <option name="x" value="953" />
     <option name="width" value="974" />
     <option name="height" value="1047" />
@@ -143,13 +156,13 @@
     <servers />
   </component>
   <component name="ToolWindowManager">
-    <frame x="-8" y="-8" width="1936" height="1056" extended-state="7" />
+    <frame x="-8" y="-8" width="1936" height="1056" extended-state="6" />
     <editor active="true" />
     <layout>
       <window_info id="Project" active="false" anchor="left" auto_hide="false" internal_type="DOCKED" type="DOCKED" visible="false" show_stripe_button="true" weight="0.12579957" sideWeight="0.5" order="0" side_tool="false" content_ui="combo" />
       <window_info id="TODO" active="false" anchor="bottom" auto_hide="false" internal_type="DOCKED" type="DOCKED" visible="false" show_stripe_button="true" weight="0.33" sideWeight="0.5" order="6" side_tool="false" content_ui="tabs" />
       <window_info id="Event Log" active="false" anchor="bottom" auto_hide="false" internal_type="DOCKED" type="DOCKED" visible="false" show_stripe_button="true" weight="0.33" sideWeight="0.5" order="7" side_tool="true" content_ui="tabs" />
-      <window_info id="Run" active="false" anchor="bottom" auto_hide="false" internal_type="DOCKED" type="DOCKED" visible="true" show_stripe_button="true" weight="0.28152174" sideWeight="0.5" order="2" side_tool="false" content_ui="tabs" />
+      <window_info id="Run" active="false" anchor="bottom" auto_hide="false" internal_type="DOCKED" type="DOCKED" visible="false" show_stripe_button="true" weight="0.28152174" sideWeight="0.5" order="2" side_tool="false" content_ui="tabs" />
       <window_info id="Version Control" active="false" anchor="bottom" auto_hide="false" internal_type="DOCKED" type="DOCKED" visible="false" show_stripe_button="true" weight="0.33" sideWeight="0.5" order="7" side_tool="false" content_ui="tabs" />
       <window_info id="Python Console" active="false" anchor="bottom" auto_hide="false" internal_type="DOCKED" type="DOCKED" visible="false" show_stripe_button="true" weight="0.32934782" sideWeight="0.5" order="7" side_tool="false" content_ui="tabs" />
       <window_info id="Structure" active="false" anchor="left" auto_hide="false" internal_type="DOCKED" type="DOCKED" visible="true" show_stripe_button="true" weight="0.25" sideWeight="0.5" order="1" side_tool="false" content_ui="tabs" />
@@ -178,7 +191,21 @@
       <provider selected="true" editor-type-id="text-editor">
         <state relative-caret-position="2499">
           <caret line="151" column="25" lean-forward="true" selection-start-line="151" selection-start-column="25" selection-end-line="151" selection-end-column="25" />
-          <folding />
+          <folding>
+            <marker date="1511510431907" expanded="true" signature="126:134" ph="&quot;&quot;&quot;...&quot;&quot;&quot;" />
+            <marker date="1511510431907" expanded="true" signature="18977:19071" ph="..." />
+            <marker date="1511510431907" expanded="true" signature="18977:19170" ph="..." />
+            <marker date="1511510431907" expanded="true" signature="19205:19301" ph="..." />
+            <marker date="1511510431907" expanded="true" signature="19324:19665" ph="..." />
+            <marker date="1511510431907" expanded="true" signature="19377:19665" ph="..." />
+            <marker date="1511510431907" expanded="true" signature="19474:19608" ph="..." />
+            <marker date="1511510431907" expanded="true" signature="19706:20248" ph="..." />
+            <marker date="1511510431907" expanded="true" signature="19763:20248" ph="..." />
+            <marker date="1511510431907" expanded="true" signature="19848:19908" ph="..." />
+            <marker date="1511510431907" expanded="true" signature="19968:20149" ph="..." />
+            <marker date="1511510431907" expanded="true" signature="19995:20149" ph="..." />
+            <marker date="1511510431907" expanded="true" signature="20311:20341" ph="..." />
+          </folding>
         </state>
       </provider>
     </entry>
@@ -194,7 +221,21 @@
       <provider selected="true" editor-type-id="text-editor">
         <state relative-caret-position="0">
           <caret line="0" column="0" lean-forward="false" selection-start-line="0" selection-start-column="0" selection-end-line="0" selection-end-column="0" />
-          <folding />
+          <folding>
+            <marker date="1511510431907" expanded="true" signature="126:134" ph="&quot;&quot;&quot;...&quot;&quot;&quot;" />
+            <marker date="1511510431907" expanded="true" signature="18977:19071" ph="..." />
+            <marker date="1511510431907" expanded="true" signature="18977:19170" ph="..." />
+            <marker date="1511510431907" expanded="true" signature="19205:19301" ph="..." />
+            <marker date="1511510431907" expanded="true" signature="19324:19665" ph="..." />
+            <marker date="1511510431907" expanded="true" signature="19377:19665" ph="..." />
+            <marker date="1511510431907" expanded="true" signature="19474:19608" ph="..." />
+            <marker date="1511510431907" expanded="true" signature="19706:20248" ph="..." />
+            <marker date="1511510431907" expanded="true" signature="19763:20248" ph="..." />
+            <marker date="1511510431907" expanded="true" signature="19848:19908" ph="..." />
+            <marker date="1511510431907" expanded="true" signature="19968:20149" ph="..." />
+            <marker date="1511510431907" expanded="true" signature="19995:20149" ph="..." />
+            <marker date="1511510431907" expanded="true" signature="20311:20341" ph="..." />
+          </folding>
         </state>
       </provider>
     </entry>
@@ -232,16 +273,30 @@
     </entry>
     <entry file="file://$PROJECT_DIR$/game_main.py">
       <provider selected="true" editor-type-id="text-editor">
-        <state relative-caret-position="619">
-          <caret line="530" column="46" lean-forward="false" selection-start-line="530" selection-start-column="46" selection-end-line="530" selection-end-column="46" />
-          <folding />
+        <state relative-caret-position="-248">
+          <caret line="475" column="46" lean-forward="false" selection-start-line="475" selection-start-column="46" selection-end-line="475" selection-end-column="46" />
+          <folding>
+            <marker date="1511510431907" expanded="true" signature="126:134" ph="&quot;&quot;&quot;...&quot;&quot;&quot;" />
+            <marker date="1511510431907" expanded="true" signature="18977:19071" ph="..." />
+            <marker date="1511510431907" expanded="true" signature="18977:19170" ph="..." />
+            <marker date="1511510431907" expanded="true" signature="19205:19301" ph="..." />
+            <marker date="1511510431907" expanded="true" signature="19324:19665" ph="..." />
+            <marker date="1511510431907" expanded="true" signature="19377:19665" ph="..." />
+            <marker date="1511510431907" expanded="true" signature="19474:19608" ph="..." />
+            <marker date="1511510431907" expanded="true" signature="19706:20248" ph="..." />
+            <marker date="1511510431907" expanded="true" signature="19763:20248" ph="..." />
+            <marker date="1511510431907" expanded="true" signature="19848:19908" ph="..." />
+            <marker date="1511510431907" expanded="true" signature="19968:20149" ph="..." />
+            <marker date="1511510431907" expanded="true" signature="19995:20149" ph="..." />
+            <marker date="1511510431907" expanded="true" signature="20311:20341" ph="..." />
+          </folding>
         </state>
       </provider>
     </entry>
     <entry file="file://$PROJECT_DIR$/game_start.txt">
       <provider selected="true" editor-type-id="text-editor">
-        <state relative-caret-position="34">
-          <caret line="2" column="90" lean-forward="false" selection-start-line="2" selection-start-column="90" selection-end-line="2" selection-end-column="90" />
+        <state relative-caret-position="1887">
+          <caret line="111" column="27" lean-forward="true" selection-start-line="111" selection-start-column="27" selection-end-line="111" selection-end-column="27" />
           <folding />
         </state>
       </provider>

--- a/game_main.py
+++ b/game_main.py
@@ -511,7 +511,7 @@ class Items:
         if player.health == 100:
             print("\nYou're not injured.")
         else:
-            player.health += 25
+            player.health += 40
             if player.health > 100:
                 player.health = 100
             self.decrement_uses()
@@ -529,6 +529,9 @@ class Items:
             current_room.enter_room()
         else:
             print("\nYou can't use that here")
+
+    # def beartrap(self):
+    #     player = Players.get_player("player")
 
     @classmethod
     def get_item(cls, name):
@@ -553,7 +556,7 @@ def main():
     # Initializes game world
     create_game_world('game_start.txt')
     player = Players('player')
-    player.current_room = Room.get_room('start')
+    player.current_room = Room.get_room('hole')
     player.current_room.enter_room()
     # Game loop
     while True:

--- a/game_main.py
+++ b/game_main.py
@@ -5,35 +5,51 @@
 # compiler: Python 3.6
 
 """
-    11/23/2017
+    11/24/2017
 
-    *Re-implemented original get_input function into combat and main game loop. The get_input receives a action list when called and only executes action if user
-    input is in the action list. The action list is also updated with the current
-    room special actions. This prevents the user from entering 'run_action' and
-    blowing the stack. As well as stops the user from calling the fight function
-    anywhere in the game map. Separating our input into a different function really
-    simplifies and prevents errors later in the code.
+    * You can now beat the game! Using the cellphone the bear drops triggers the endgame sequence.
 
-    * Enemies now drop loot at the end of combat. Loot is auto-picked up by the
-    player
+    *Added text block of endgame sequence to game_start.txt. victory() parses and
+    prints this to screen.
 
-    * On failed run away attempts the enemy will now take a free turn. instead of
-    a flat -10 damage to player.
+    *Added new action 'status'. If player types status the game will print out
+    the players health, equipped weapon & stats. The current room, available actions
+    branches, and items for that room.
 
-    * Changed the while loops from while True to while player.health > 0:
-    this allows the keypad function to terminate if the player dies.
+    *After combat the game will now print post combat room descriptions.
+
+    *Updated the room descriptions in game_start to reflect post-combat descriptions
+    and examine room descriptions. Altered some text in the descriptions to alert
+    user to items and actions available in the room.
+
+    *According to orignal game document we needed to include a priceless aztec statue
+    in our story. I added a STATUE room that connects to the lab. upon entering the
+    player is confronted with a choice of taking the statue or leaving it. If you take
+    it springs an arrow trap and kills the player.
+
+    *Added new weapon, spear. Added it to wolf's loot table.
+
+    *rat now drops a knife.
+
+    *Beartrap is fully functional! It deals 100 damage to the enemy. and can only be
+    used in combat.
+
+    *Updated help function
+
+    *Keypad minigame can now kill the player.
 
     * Need to make death method functional and dynamic
 
-    * Need to populate game_start.txt with actual game text
-
     * Need to create a tutorial or readme.txt file for game
+
+    * Do we need a gun? It may be a little too powerful in conjuntion with the bear
+    trap. It will also require a special attribtue linked to the number of bullets in
+    players inventory.
+
+    * I like the combat changes to health and weapon damage! Combat feels very balanced!
 
     * Look into saving game state
 
-    *condense object grabbing in the action methods into a separate method for ease of use.
-
-    *Look into creating convenience methods for lines of code I reuse alot.
 """
 import csv
 import textwrap
@@ -52,7 +68,7 @@ class Players:
         self.health = health
         self.equipped_weapon = None
         self.inventory = Players.initialize_inventory(name)
-        self.equipped_weapon = Players.initial_equip(name)
+        self.equipped_weapon = self.inventory[0]
         self.dignity = dignity  # Haven't found a use for this attribute yet.
         self.current_room = None
         self.player_objects.append(self)
@@ -117,6 +133,7 @@ class Players:
             self.current_room.events = 'None'
             Players.player_objects.remove(enemy)
             del enemy
+            self.current_room.enter_room()
         if self.health <= 0:
             print("\nYou were deafeated by {}".format(enemy.name))
             death("GAME OVER")
@@ -150,14 +167,6 @@ class Players:
             inventory.append(i)
         return inventory
 
-    @classmethod
-    def initial_equip(cls, name):
-        item_list = parse_file('game_start.txt', name, '*player_inventory')
-        for i in item_list:
-            for w in Weapons.weapon_objects:
-                if i == w.name:
-                    return w
-
 
 class Enemy(Players):
     """Creates enemy object for use in story"""
@@ -166,7 +175,7 @@ class Enemy(Players):
         super().__init__(name, health)
 
     def enemy_turn(self):
-        if self.health <= 0:
+        if self.health <= 0:  # Prevents enemy from taking another turn after killed
             print("\nThe {} was killed!".format(self.name))
         else:
             player = Players.get_player('player')
@@ -227,8 +236,7 @@ class Room:
                 self.description[int(self.lock_description[1])]))
         else:
             try:
-                print(
-                    '\n' + textwrap.fill(self.description[self.counter]))
+                print('\n' + textwrap.fill(self.description[self.counter]))
             except IndexError:
                 print('\n' + textwrap.fill(self.description[-1]))
             self.increment_counter()
@@ -245,14 +253,14 @@ class Room:
     def increment_counter(self):
         self.counter += 1
 
-    def keypad(self):  # Need to implement death
+    def keypad(self):
         player = Players.get_player("player")
         code = "6824"
         while player.health > 0:
             player_attempt = input(
                 "Enter code (type \"back\" to back out):\n>  ")
             if player_attempt == code:
-                self.next_room('boss_room')
+                self.next_room('secret')
                 break
             elif player_attempt.lower() == "back":
                 self.next_room(self.branches[0])
@@ -264,8 +272,24 @@ class Room:
                 player.health -= 25
             else:
                 print("\nThe keypad lets out a quizical beep. (Invalid input)")
-        print("\nThat was stupid, death by keypad")
-        death("GAME OVER")
+        if player.health <= 0:
+            print("\nThat was stupid, death by keypad")
+            death("GAME OVER")
+
+    def aztec_statue(self):  # Special endgame scenario
+        while True:
+            choice = input("\nDo you take the statue? (yes or no)\n>  ")
+            if choice in ('y', 'yes'):
+                print("The statue was rigged to an arrow trap at the rear of the room"
+                      "\nYour greed was the death of you.")
+                death("GAME OVER")
+            elif choice in ('n', 'no'):
+                print("Your instinct yells at you to back away from the statue."
+                      "\nYou back away slowly and return to the LAB.")
+                self.next_room('lab')
+                break
+            else:
+                print("Sorry, I don't understand. type 'Yes' or 'No'")
 
     @classmethod
     def get_room(cls, name):
@@ -282,10 +306,7 @@ class Actions:
         self.args = [arg for a in args for arg in a]
 
     def run_action(self):
-        try:
-            eval('self.' + self.verb + '()')
-        except AttributeError:
-            print("\nHuh? (Invalid input. Type \"help\" for help)")
+        eval('self.' + self.verb + '()')
 
     def help(self):
         player = Players.get_player('player')
@@ -295,12 +316,34 @@ class Actions:
             Here is a list of commands:
             ==================================================
 
-            goto, examine, use, pickup, inventory, equip, quit
+            goto, examine, use, pickup, inventory, equip, status, quit
 
             ==================================================
 
             Special commands for this room: {}
             """.format(special_actions)))
+
+    def status(self):
+        player = Players.get_player('player')
+        weapon = player.equipped_weapon
+        room = player.current_room
+        try:
+            items = [i.name for i in room.items]
+        except AttributeError:
+            items = ['None']
+        print(textwrap.dedent(
+            """
+            STATUS:
+            ==============================
+            HEALTH:          {}/100
+            EQUIPPED WEAPON: {} DMG:{}  ACC:{}
+            CURRENT ROOM:    {}
+            ROOM ACTIONS:    {}
+            ROOM BRANCHES:   {}
+            ROOM ITEMS:      {}
+            """.format(player.health, weapon.name.capitalize(), weapon.dmg,
+                       weapon.acc, room.name.capitalize(), room.actions,
+                       room.branches, items)))
 
     def goto(self):
         player = Players.get_player('player')
@@ -385,7 +428,6 @@ class Actions:
         else:
             print("\nThere is no {} to use".format(item_name))
 
-    # BUG: Fixed by using original get_input method.
     def fight(self):
         # Grab needed objects
         player = Players.get_player('player')
@@ -396,13 +438,12 @@ class Actions:
         accuracy_roll = weapon.acc + randint(1, 100)
         print("You attack!. . . .")
         time.sleep(1.5)
-        if accuracy_roll > 100:  # Accuracy role must be over 100 to do anything.
-            if accuracy_roll > 85 + weapon.acc:  # If the random number was 86-100, critical hit,
+        if accuracy_roll > 100:
+            if accuracy_roll > 85 + weapon.acc:
                 print("\nCritical hit!!! You hit {} for {} damage"
                       .format(enemy.name, int(weapon.dmg * 1.5)))
                 enemy.health -= int(weapon.dmg * 1.5)
             else:
-                # Else, damage normal, give or take 5 from base weapon.
                 damage_roll = weapon.dmg + randint(-5, 5)
                 print("\nYou hit {} for {} damage".format(
                     enemy.name, damage_roll))
@@ -413,7 +454,7 @@ class Actions:
         time.sleep(1)
 
     def quit(self):
-        print("\nAre you sure you want to quit? Nothing will be saved.")
+        print("\nAre you sure you want to quit? Nothing will be saved. (yes or no)")
         opt = input(">  ").lower()
         if opt in ('y', 'yes'):  # This prevents use from typing 'you' or any word
             quit()               # with 'y' and quitting the game.
@@ -470,13 +511,37 @@ class Items:
             current_room.lock_description[0] = 'False'
             print("\nYou lit your {}".format(self.name))
             self.decrement_uses()
-            current_room.increment_counter()
+            current_room.counter = 1
             current_room.enter_room()
         else:
             print("\nYou can't use that here")
 
-    # def beartrap(self):
-    #     player = Players.get_player("player")
+    def beartrap(self):
+        player = Players.get_player("player")
+        current_room = player.current_room
+        enemy = current_room.enemies
+        if enemy == None:
+            print("\nYou can't use that here. Try to use this in combat")
+        else:
+            print("\nYou quickly set the trap in front of you.")
+            print("You yell at the {}, baiting it to attack you.".format(enemy.name))
+            time.sleep(2)
+            print("\nThe {0} takes the bait! it jumps for your throat!"
+                  "\nYou dodge at the last moment forcing the {0} to land on the trap"
+                  "\n\n{0} takes 100 damage!!".format(enemy.name))
+            time.sleep(2)
+            enemy.health -= 100
+            self.decrement_uses()
+
+            print(" ")
+
+    def victory(self):
+        victory = parse_file(
+            'game_start.txt', 'cellphone', '*victory_sequence')
+        for v in victory:
+            print('\n' + textwrap.fill(v))
+            time.sleep(4)
+        quit()
 
     @classmethod
     def get_item(cls, name):
@@ -504,7 +569,7 @@ def main():
     player.current_room = Room.get_room('hole')
     player.current_room.enter_room()
     action_list = ['goto', 'pickup', 'examine',
-                   'use', 'help', 'inventory', 'equip', 'quit']
+                   'use', 'help', 'inventory', 'equip', 'status', 'quit']
     # Game loop
     while player.health > 0:
         opt = get_input(">  ", player.current_room, action_list)
@@ -568,7 +633,6 @@ def parse_file(filename, key, target):
             return None
 
 
-# Need to fully implement death function
 def death(message):
     print(message)
     quit()

--- a/game_start.txt
+++ b/game_start.txt
@@ -1,19 +1,20 @@
 *rooms
 GAME:           ROOMS:
-survival_game|  hole|  left|   rat|  tunnel| extension | waterfall|  lab|   secret|   cage
+survival_game|  hole|  left|   rat|  tunnel| extension | waterfall|  lab| secret|   cage| statue
 *end_rooms
 
 *room_descriptions
 ROOM:         DESCRIPTIONS:
-hole|         You awake to see yourself looking at the light from a HOLE in the ceiling. You look around. It seems you've fallen into a cave. There are two paths, to your LEFT you hear the soft sound of running water. To your right, you hear the squeaks of what seem to be a RAT. Which way do you go? Type "help" for help.|    You remember this room like you remember the bruise on the back of your head. To your LEFT you hear the soft sound of running water. To your right, you hear the squeaks of what seem to be a RAT.
-left|         Somehow, your legs are functional and manage to carry you from room to room. This is fortunate, because a torch on the wall reveals another fork in the path, with more rooms. You may follow the sounds of the water to the WATERFALL, walk into the dark, scary TUNNEL, head back to the HOLE you fell into, or perhaps stay and examine the place!| This place is small and claustrophobic, you think to yourself. You can go to the WATERFALL, the dark TUNNEL, or the HOLE where you began.
-rat|          You walk towards the sound of a rat. You're shocked. It's a rat.
-tunnel|       It's too dark. You let your eyes adjust. It's still too dark. However, you do hear the snarl of an angry canine. You can't go on further, you must head back LEFT.|  Your torch illuminates a fearsome wolf gnawing on fresh meat. After the fight, you may head back LEFT or continue onto the EXTENSION.
-extension|    The end of the road. Your torch illuminates a corpse lying against a wall, and a beartrap sits patiently next to you. Looks like there's nothing you can do but head back into the TUNNEL.
-secret|       Clicks and clacks of mechanisms hidden within the walls begin, and the door slowly opens up revealing a dimly lit, but otherwise well decorated room. The walls are made up metal, and this place seemingly looks like a lobby of some sort. Furniture is knocked over, papers everywhere, the room is a mess, but you can tell this once held a safe work environment for...someone. You try the doors, and they're all locked except for two. A room with a CAGE startles you as a wolf attempts to jump at you in rage. However, you do spot a couple .50 caliber bullets lying within the cage. The only other available room is one labeled LAB. If you'd like, you can head back to the WATERFALL. | This lobby-esqe room is irksome. You wonder what happened here. You can head into the LAB, "greet" the wolf in the CAGE, or head back into the WATERFALL.
-cage|         A fearsome wolf is ready to unleash its rage!
+hole|         You awake to see yourself looking at the light from a HOLE in the ceiling. You look around. It seems you've fallen into a cave. There is a Bandage on the ground, which may be useful. There are two paths, to your LEFT you hear the soft sound of running water. To your right, you hear the squeaks of what seem to be a RAT. Which way do you go? Type "help" for help.|    You remember this room like you remember the bruise on the back of your head. To your LEFT you hear the soft sound of running water. To your right, is the room with the RAT.
+left|         Somehow, your legs are functional and manage to carry you from room to room. This is fortunate, because a Torch on the wall reveals another fork in the path, with more rooms. You may follow water to the WATERFALL, walk into the dark, scary TUNNEL, head back to the HOLE you fell into, or perhaps stay and Examine the place!| This place is small and claustrophobic, you think to yourself. You can go to the WATERFALL, the dark TUNNEL, or the HOLE where you began.| Looking closer at your surroundings you see a Body next to the water. You may want to examine the Body, or maybe get a Drink of the water. You are thirsty after all. Also, picking up that Torch may be a good idea. You can go to WATERFALL or the  TUNNEL
+rat|          You walk towards the sound of a rat. You're shocked. It's a rat.| With the rat dead there's nothing left to examine in this room. You can goto HOLE, where you started.
+tunnel|       It's too dark. You let your eyes adjust. It's still too dark, maybe if you had a Torch. However, you do hear the snarl of an angry canine. You can't go on further, you must head back LEFT.|  Your torch illuminates a fearsome wolf gnawing on fresh meat.| With the wolf dead, you may head back LEFT or continue onto the EXTENSION.
+extension|    The end of the road. Your torch illuminates a Corpse lying against a wall, and a unused Beartrap sits patiently next to you. Looks like there's nothing you can do but head back into the TUNNEL.| End of the road, the corpse is still here but maybe you should head back to TUNNEL.
+secret|       Clicks and clacks of mechanisms hidden within the walls begin, and the door slowly opens up revealing a dimly lit, but otherwise well decorated room. The walls are made of metal, and this place seemingly looks like a lobby of some sort. Furniture is knocked over, papers everywhere, the room is a mess, but you can tell this once held a safe work environment for...someone. You try the doors, and they're all locked except for two. A room with a CAGE startles you as a wolf attempts to jump at you in rage. However, you do spot a couple .45 magnum rounds lying within the cage. The only other available room is one labeled LAB. If you'd like, you can head back to the WATERFALL. | This lobby-esqe room is irksome. You wonder what happened here. You can head into the LAB, "greet" the wolf in the CAGE, or head back into the WATERFALL.
+cage|         A fearsome wolf is ready to unleash its rage!| With the wolf dead, it looks like you can pick up those bullets and head back to the SECRET room.
 waterfall|    You follow the sounds to a waterfall. The water looks odd, and illuminates the cave. What's that at the base of it? You walk through the water to reveal a securely locked door with a keypad! It has four digit slots, waiting for input. What could possibly be on the other side? | The waterfall is pretty, but its slight glow is off-putting. You step up to the keypad.
-lab|          You slide the lab door open, revealing a large, starving bear helping itself to a poor sucker in a lab coat. Uh oh, this is not going to end well!
+lab|          You slide the lab door open, revealing a large, starving bear helping itself to a poor sucker in a lab coat. Uh oh, this is not going to end well!| With the bear defeated you notice a priceless aztec STATUE sitting firmly upon an altar at the rear of the room. You can goto the STATUE, or it might be a good idea to just use that cellphone and get the hell out of here.
+statue|      You approach the priceless Aztec statue. It is the most glorious object you have ever laid eyes on. It's worth could bring you countless fortune and would make this hell-ish adventure worth it's literal weight in gold.
 *end_room_descriptions
 
 *room_branches
@@ -26,33 +27,36 @@ extension|  tunnel
 waterfall|  left|  secret
 secret|     waterfall|  lab  | cage
 cage|       secret
-lab|        secret
+lab|        secret| statue
+statue|     lab
 *end_room_branches
 
 *room_count
-ROOMS:  COUNT:
-hole|  0
-left|   0
-rat|  0
-tunnel| 0
+ROOMS:      COUNT:
+hole|       0
+left|       0
+rat|        0
+tunnel|     0
 waterfall|  0
 extension|  0
-secret|  0
-cage|  0
-lab|  0
+secret|     0
+cage|       0
+lab|        0
+statue|     0
 *end_room_count
 
 *room_items
 ROOM:   ITEM:
-hole|  bandage
-left|   corpse| torch
-rat|  bandage|  knife
+hole|  None
+left|   body| torch
+rat|  bandage
 tunnel| None
 waterfall| None
-extension|  code|  gun|  beartrap
+extension|  code|  gun|  corpse| beartrap
 secret| None
 cage|  bullet|  bandage
-lab| cellphone
+lab| None
+statue| None
 *end_room_items
 
 *room_events
@@ -66,6 +70,7 @@ waterfall| self.keypad()
 secret|  None
 cage|   self.encounter()
 lab|  self.encounter()
+statue| self.aztec_statue()
 *end_room_events
 
 *room_actions
@@ -79,40 +84,43 @@ waterfall|  None
 secret|   None
 cage|  None
 lab|  None
+statue| None
 *end_room_actions
 
 *room_lock_description
-ROOM:   LOCK:   DESCRIPTION_INDEX:
-hole|  False|  None
-left|   False|  None
-rat|  False|  None
-tunnel| True|   0
+ROOM:       LOCK:       DESCRIPTION_INDEX:
+hole|       False|  None
+left|       False|  None
+rat|        False|  None
+tunnel|     True|   0
 extension|  False|  None
-waterfall| False|   None
-secret|  False|  None
-cage|  False|  None
-lab|  False|  None
+waterfall|  False|  None
+secret|     False|  None
+cage|       False|  None
+lab|        False|  None
+statue|     False|  None
 *end_room_lock_description
 
 *room_enemies
 ROOM:   ENEMIES & HEALTH:
-hole|  None
-left|   None
-rat|  rat| 50
-tunnel| wolf| 70
+hole|       None
+left|       None
+rat|        rat|    50
+tunnel|     wolf|   70
 extension|  None
-lab|  bear| 200
-secret|   None
-cage| wolf| 70
+lab|        bear|   200
+secret|     None
+cage|       wolf|   70
 waterfall|  None
+statue|     None
 
 *player_inventory
 PLAYER:     ITEM:
 None|       None
 player|     fists|  bandage
-rat|        small_claws
-wolf|       claws
-bear|       big_claws
+rat|        small_claws| knife
+wolf|       claws| spear| bandage
+bear|       big_claws| cellphone
 *end_player_inventory
 
 *items
@@ -120,8 +128,9 @@ ITEM:       USES:   FUNCTION:       PICKUP: DESCRIPTION:
 bandage|    2|      heal()|         True|   A regular bandage. Heals 40 health.
 code|       1|      None|           True|   The note reads:  Door code: 6824
 corpse|     0|      None|           False|  This corpse is smelly and looks as if it has been mauled. In the left hand, a CODE. In the right, a GUN.
-cellphone|  1|      None|           True|   A flip phone that miraculously has signal! (This should trigger end of the game)
-beartrap|   1|      None|           True|   A loaded bear trap, good for one use with deadly results.
+body|       0|      None|           False|  The body is old, and rotting. There are no signs of a struggle. The only clue to his death is the pile of vomit near the water.
+cellphone|  1|      victory()|      True|   A flip phone that miraculously has signal!
+beartrap|   1|      beartrap()|           True|   A loaded bear trap, good for one use with deadly results.
 torch|      1|      light()|        True|   A torch that, miraculously, can be lit. Just like the movies.
 bullet|     2|      load_gun()|     True|   The bullet is a .44 Magnum, it'll stop anything in it's tracks.
 *end_items
@@ -130,8 +139,14 @@ bullet|     2|      load_gun()|     True|   The bullet is a .44 Magnum, it'll st
 WEAPONS:    USES:   FUNCTION:   PICKUP: DMG:    ACC:     DESCRIPTION:
 fists|      1|      None|       False|  15|     70|    They're your own fists, what's there to examine??
 knife|      1|      None|       True|   30|     75|    Rusty old combat knife with 'DHARMA initiative' inscribed on the hilt
+spear|      1|      None|       True|   40|     70|     Crude, but effective, spear.
 gun|        0|      load_gun(object)|   True|   100|    50| Smith & Wesson 500, a powerful magnum.
 small_claws| 1|     None|       False|    10|    60|    Small, skittish claws.
 claws|      1|      None|       False|   20|     60|     Big, strong wolf claws.
 big_claws|   1|     None|       False|  35|     65|     You thought the wolf claws were big??
 *end_weapons
+
+*victory_sequence
+VICTORY:    SEQUENCE:
+cellphone|  The phone is about to die. Its battery is at 3%, you have time for only one call. You dial 911 and quickly explain to the dispatcher where to look for you. As you finish your story the phone cuts out and dies. There's nothing left to do but wait.| 3 hours later, you hear some commotion. It's the rescue team here to save you from this wretched cave!| Congratulations you survived and beat the game!!| Game credits: Alexander DuPree, Jacob Bickle. Thanks for playing!!
+*end_victory_sequence

--- a/game_start.txt
+++ b/game_start.txt
@@ -109,20 +109,14 @@ waterfall|  None
 *player_inventory
 PLAYER:     ITEM:
 None|       None
-<<<<<<< HEAD
-player|     fists|  bandage|   code
+player|     fists|  bandage
 rat|        small_claws
 wolf|       claws
-=======
-player|     fists|  bandage
-wolf|       claws|  knife| bandage| note
->>>>>>> 674c0f28590fed4fcb4509aa761b0182b7a3f6c2
 bear|       big_claws
 *end_player_inventory
 
 *items
 ITEM:       USES:   FUNCTION:       PICKUP: DESCRIPTION:
-<<<<<<< HEAD
 bandage|    2|      heal()|         True|   A regular bandage. Heals 40 health.
 code|       1|      None|           True|   The note reads:  Door code: 6824
 corpse|     0|      None|           False|  This corpse is smelly and looks as if it has been mauled. In the left hand, a CODE. In the right, a GUN.
@@ -130,25 +124,12 @@ cellphone|  1|      None|           True|   A flip phone that miraculously has s
 beartrap|   1|      None|           True|   A loaded bear trap, good for one use with deadly results.
 torch|      1|      light()|        True|   A torch that, miraculously, can be lit. Just like the movies.
 bullet|     2|      load_gun()|     True|   The bullet is a .44 Magnum, it'll stop anything in it's tracks.
-=======
-bandage|    1|      heal()|         True|   regular bandage, for use on wounds.
-matches|    1|      None|           True|   Just standard wooden matches
-note|       1|      None|           True|   The note reads:  Door code: 6824
-corpse|     0|      None|           False|  The corpse is old and stinky
-torch|      1|      light()|        True|   A torch that, miracously, can be lit. Just like the movies.
-bullet|     1|      load_gun()|     True|   The bullet is a .44 Magnum, it'll stop anything in it's tracks.
->>>>>>> 674c0f28590fed4fcb4509aa761b0182b7a3f6c2
 *end_items
 
 *weapons
 WEAPONS:    USES:   FUNCTION:   PICKUP: DMG:    ACC:     DESCRIPTION:
-<<<<<<< HEAD
 fists|      1|      None|       False|  15|     70|    They're your own fists, what's there to examine??
 knife|      1|      None|       True|   30|     75|    Rusty old combat knife with 'DHARMA initiative' inscribed on the hilt
-=======
-fists|      1|    None|       False|  15|     70|    They're your own fists, what's there to examine??
-knife|      1|     None|       True|   50|     75|    Rusty old combat knife with 'DHARMA initiative' inscribed on the hilt
->>>>>>> 674c0f28590fed4fcb4509aa761b0182b7a3f6c2
 gun|        0|      load_gun(object)|   True|   100|    50| Smith & Wesson 500, a powerful magnum.
 small_claws| 1|     None|       False|    10|    60|    Small, skittish claws.
 claws|      1|      None|       False|   20|     60|     Big, strong wolf claws.

--- a/game_start.txt
+++ b/game_start.txt
@@ -1,110 +1,137 @@
 *rooms
 GAME:           ROOMS:
-survival_game|  start|  left|   right|  tunnel| waterfall|  boss_room
+survival_game|  hole|  left|   rat|  tunnel| extension | waterfall|  lab|   secret|   cage
 *end_rooms
 
 *room_descriptions
 ROOM:         DESCRIPTIONS:
-start|        You awake to see yourself looking at the light from a hole in the ceiling. You look around. It seems you've fallen into a cave. There are two paths, to your LEFT you hear the soft sound of running water. To your RIGHT, you hear a snarl in the dark. Which way do you go?|    SSart room second dcription
-left|         left room first description| left room second description
-right|        test wolf encounter
-tunnel|       It's too dark, you can't see. Maybe if you had a torch.|  Your torch illuminates a fearsome wolf gnawing on a freshly killed corpse.
-waterfall|     Behind the waterfall theres a door! You notice an old looking keypad. It has four digit slots that are blank.
-boss_room|     The door swings open revealing the BOSS FIGHT!
+hole|         You awake to see yourself looking at the light from a HOLE in the ceiling. You look around. It seems you've fallen into a cave. There are two paths, to your LEFT you hear the soft sound of running water. To your right, you hear the squeaks of what seem to be a RAT. Which way do you go? Type "help" for help.|    You remember this room like you remember the bruise on the back of your head. To your LEFT you hear the soft sound of running water. To your right, you hear the squeaks of what seem to be a RAT.
+left|         Somehow, your legs are functional and manage to carry you from room to room. This is fortunate, because a torch on the wall reveals another fork in the path, with more rooms. You may follow the sounds of the water to the WATERFALL, walk into the dark, scary TUNNEL, head back to the HOLE you fell into, or perhaps stay and examine the place!| This place is small and claustrophobic, you think to yourself. You can go to the WATERFALL, the dark TUNNEL, or the HOLE where you began.
+rat|          You walk towards the sound of a rat. You're shocked. It's a rat.
+tunnel|       It's too dark. You let your eyes adjust. It's still too dark. However, you do hear the snarl of an angry canine. You can't go on further, you must head back LEFT.|  Your torch illuminates a fearsome wolf gnawing on fresh meat. After the fight, you may head back LEFT or continue onto the EXTENSION.
+extension|    The end of the road. Your torch illuminates a corpse lying against a wall, and a beartrap sits patiently next to you. Looks like there's nothing you can do but head back into the TUNNEL.
+secret|       Clicks and clacks of mechanisms hidden within the walls begin, and the door slowly opens up revealing a dimly lit, but otherwise well decorated room. The walls are made up metal, and this place seemingly looks like a lobby of some sort. Furniture is knocked over, papers everywhere, the room is a mess, but you can tell this once held a safe work environment for...someone. You try the doors, and they're all locked except for two. A room with a CAGE startles you as a wolf attempts to jump at you in rage. However, you do spot a couple .50 caliber bullets lying within the cage. The only other available room is one labeled LAB. If you'd like, you can head back to the WATERFALL. | This lobby-esqe room is irksome. You wonder what happened here. You can head into the LAB, "greet" the wolf in the CAGE, or head back into the WATERFALL.
+cage|         A fearsome wolf is ready to unleash its rage!
+waterfall|    You follow the sounds to a waterfall. The water looks odd, and illuminates the cave. What's that at the base of it? You walk through the water to reveal a securely locked door with a keypad! It has four digit slots, waiting for input. What could possibly be on the other side? | The waterfall is pretty, but its slight glow is off-putting. You step up to the keypad.
+lab|          You slide the lab door open, revealing a large, starving bear helping itself to a poor sucker in a lab coat. Uh oh, this is not going to end well!
 *end_room_descriptions
 
 *room_branches
 ROOM:       BRANCHES:
-start|      left|       right
-left|       start|  tunnel| waterfall
-right|      start
-tunnel|     left
-waterfall|  left| boss_room
-boss_room|  None
+hole|       left|  rat
+left|       hole|  tunnel| waterfall
+rat|        hole
+tunnel|     left|  extension
+extension|  tunnel
+waterfall|  left|  secret
+secret|     waterfall|  lab  | cage
+cage|       secret
+lab|        secret
 *end_room_branches
 
 *room_count
 ROOMS:  COUNT:
-start|  0
+hole|  0
 left|   0
-right|  0
+rat|  0
 tunnel| 0
 waterfall|  0
-boss_room|  0
+extension|  0
+secret|  0
+cage|  0
+lab|  0
 *end_room_count
 
 *room_items
 ROOM:   ITEM:
-start|  bandage| knife
+hole|  bandage
 left|   corpse| torch
-right|  None
-tunnel| bullet
+rat|  bandage|  knife
+tunnel| None
 waterfall| None
-boss_room| None
+extension|  code|  gun|  beartrap
+secret| None
+cage|  bullet|  bandage
+lab| cellphone
 *end_room_items
 
 *room_events
 ROOM:   EVENT:
-start|  None
+hole|  None
 left|   None
-right|  self.encounter()
+rat|  self.encounter()
 tunnel| self.encounter()
+extension|  None
 waterfall| self.keypad()
-boss_room|  self.encounter()
+secret|  None
+cage|   self.encounter()
+lab|  self.encounter()
 *end_room_events
 
 *room_actions
 ROOM:   ACTION:
-start|  None
+hole|  None
 left|   drink
-right|  None
+rat|  None
 tunnel| pet
+extension|   None
 waterfall|  None
-boss_room|  None
+secret|   None
+cage|  None
+lab|  None
 *end_room_actions
 
 *room_lock_description
 ROOM:   LOCK:   DESCRIPTION_INDEX:
-start|  False|  None
+hole|  False|  None
 left|   False|  None
-right|  False|  None
+rat|  False|  None
 tunnel| True|   0
+extension|  False|  None
 waterfall| False|   None
-boss_room|  False|  None
+secret|  False|  None
+cage|  False|  None
+lab|  False|  None
 *end_room_lock_description
 
 *room_enemies
 ROOM:   ENEMIES & HEALTH:
-start|  None
+hole|  None
 left|   None
-right|  wolf| 100
-tunnel| wolf| 100
-boss_room|  bear| 150
+rat|  rat| 50
+tunnel| wolf| 70
+extension|  None
+lab|  bear| 200
+secret|   None
+cage| wolf| 70
 waterfall|  None
 
 *player_inventory
 PLAYER:     ITEM:
 None|       None
-player|     fists|  bandage
+player|     fists|  bandage|   code
+rat|        small_claws
 wolf|       claws
 bear|       big_claws
 *end_player_inventory
 
 *items
 ITEM:       USES:   FUNCTION:       PICKUP: DESCRIPTION:
-bandage|    1|      heal()|         True|   regular bandage, for use on wounds.
-matches|    1|      None|           True|   Just standard wooden matches
-note|       0|      None|           True|   The note reads:  Door code: 6824
-corpse|     0|      None|           False|  The corpse is old and stinky
-torch|      1|      light()|        True|   A torch that, miracously, can be lit. Just like the movies.
-bullet|     1|      load_gun()|     True|   The bullet is a .44 Magnum, it'll stop anything in it's tracks.
+bandage|    2|      heal()|         True|   A regular bandage. Heals 40 health.
+code|       1|      None|           True|   The note reads:  Door code: 6824
+corpse|     0|      None|           False|  This corpse is smelly and looks as if it has been mauled. In the left hand, a CODE. In the right, a GUN.
+cellphone|  1|      None|           True|   A flip phone that miraculously has signal! (This should trigger end of the game)
+beartrap|   1|      None|           True|   A loaded bear trap, good for one use with deadly results.
+torch|      1|      light()|        True|   A torch that, miraculously, can be lit. Just like the movies.
+bullet|     2|      load_gun()|     True|   The bullet is a .44 Magnum, it'll stop anything in it's tracks.
 *end_items
 
 *weapons
 WEAPONS:    USES:   FUNCTION:   PICKUP: DMG:    ACC:     DESCRIPTION:
-fists|      1|    None|       False|  15|     70|    They're your own fists, what's there to examine??
-knife|      1|     None|       True|   30|     75|    Rusty old combat knife with 'DHARMA initiative' inscribed on the hilt
+fists|      1|      None|       False|  15|     70|    They're your own fists, what's there to examine??
+knife|      1|      None|       True|   30|     75|    Rusty old combat knife with 'DHARMA initiative' inscribed on the hilt
 gun|        0|      load_gun(object)|   True|   100|    50| Smith & Wesson 500, a powerful magnum.
-claws|      1|    None|       False|   20|     60|     Big ass wolf claws
-big_claws|   1|    None|       False|  35|     65|     You thought the wolf claws were big??
+small_claws| 1|     None|       False|    10|    60|    Small, skittish claws.
+claws|      1|      None|       False|   20|     60|     Big, strong wolf claws.
+big_claws|   1|     None|       False|  35|     65|     You thought the wolf claws were big??
 *end_weapons

--- a/game_start.txt
+++ b/game_start.txt
@@ -109,9 +109,14 @@ waterfall|  None
 *player_inventory
 PLAYER:     ITEM:
 None|       None
+<<<<<<< HEAD
 player|     fists|  bandage|   code
 rat|        small_claws
 wolf|       claws
+=======
+player|     fists|  bandage
+wolf|       claws|  knife| bandage| note
+>>>>>>> 674c0f28590fed4fcb4509aa761b0182b7a3f6c2
 bear|       big_claws
 *end_player_inventory
 


### PR DESCRIPTION
    * You can now beat the game! Using the cellphone the bear drops triggers the endgame sequence.

    *Added text block of endgame sequence to game_start.txt. victory() parses and
    prints this to screen.

    *Added new action 'status'. If player types status the game will print out
    the players health, equipped weapon & stats. The current room, available actions
    branches, and items for that room.

    *After combat the game will now print post combat room descriptions.

    *Updated the room descriptions in game_start to reflect post-combat descriptions
    and examine room descriptions. Altered some text in the descriptions to alert
    user to items and actions available in the room.

    *According to orignal game document we needed to include a priceless aztec statue
    in our story. I added a STATUE room that connects to the lab. upon entering the
    player is confronted with a choice of taking the statue or leaving it. If you take
    it springs an arrow trap and kills the player.

    *Added new weapon, spear. Added it to wolf's loot table.

    *rat now drops a knife.

    *Beartrap is fully functional! It deals 100 damage to the enemy. and can only be
    used in combat.

    *Updated help function

    *Keypad minigame can now kill the player.

    * Need to make death method functional and dynamic

    * Need to create a tutorial or readme.txt file for game

    * Do we need a gun? It may be a little too powerful in conjuntion with the bear
    trap. It will also require a special attribtue linked to the number of bullets in
    players inventory.

    * I like the combat changes to health and weapon damage! Combat feels very balanced!

    * Look into saving game state